### PR TITLE
[feat-customer] 체험단 브랜드 페이지에서 닉네임 수정 API 개발 및 관련 util, config, dto 생성

### DIFF
--- a/src/main/java/com/nuguna/freview/config/DbConfig.java
+++ b/src/main/java/com/nuguna/freview/config/DbConfig.java
@@ -2,9 +2,9 @@ package com.nuguna.freview.config;
 
 public class DbConfig {
 
-  public static final String DB_URL = "jdbc:mariadb://localhost:3306/test";
+  public static final String DB_URL = "jdbc:mariadb://localhost:3306/freview";
   public static final String DB_USER = "root";
-  public static final String DB_PW = "";
+  public static final String DB_PW = "0000";
   public static final String DRIVER_NAME = "org.mariadb.jdbc.Driver";
 
 }

--- a/src/main/java/com/nuguna/freview/dao/member/CustBrandDAO.java
+++ b/src/main/java/com/nuguna/freview/dao/member/CustBrandDAO.java
@@ -1,2 +1,60 @@
-package com.nuguna.freview.dao.member;public class CustBrandDAO {
+package com.nuguna.freview.dao.member;
+
+import static com.nuguna.freview.util.DbUtil.*;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CustBrandDAO {
+
+  public boolean checkNicknameIsExist(String toNickname) {
+      Connection conn = null;
+      PreparedStatement pstmt = null;
+      ResultSet rs = null;
+
+      String sql = "SELECT member_seq "
+          + "FROM MEMBER "
+          + "WHERE NICKNAME = ?";
+
+      boolean checkResult = false;
+      try {
+        conn = getConnection();
+        pstmt = conn.prepareStatement(sql);
+        pstmt.setString(1, toNickname);
+        rs = pstmt.executeQuery();
+
+        if(rs.next()){
+          checkResult = true;
+        }
+      } catch (SQLException e) {
+        throw new RuntimeException("SQLException : 닉네임 체크 도중 예외 발생",e);
+      } finally {
+        closeResource(pstmt, conn, rs);
+      }
+    return checkResult;
+  }
+
+  public void updateNickname(int memberSeq, String toNickname) {
+    Connection conn = null;
+    PreparedStatement pstmt = null;
+
+    String sql = "UPDATE MEMBER "
+        + "SET nickname = ? "
+        + "WHERE member_seq = ?";
+    try {
+      conn = getConnection();
+      pstmt = conn.prepareStatement(sql);
+      pstmt.setString(1, toNickname);
+      pstmt.setInt(2, memberSeq);
+      pstmt.executeUpdate();
+    } catch (SQLException e) {
+      throw new RuntimeException("SQLException : 닉네임 변경 도중 예외 발생" , e);
+    } finally {
+      closeResource(pstmt, conn);
+    }
+  }
 }

--- a/src/main/java/com/nuguna/freview/dao/member/CustBrandDAO.java
+++ b/src/main/java/com/nuguna/freview/dao/member/CustBrandDAO.java
@@ -1,0 +1,2 @@
+package com.nuguna.freview.dao.member;public class CustBrandDAO {
+}

--- a/src/main/java/com/nuguna/freview/dto/common/ResponseMessage.java
+++ b/src/main/java/com/nuguna/freview/dto/common/ResponseMessage.java
@@ -1,0 +1,13 @@
+package com.nuguna.freview.dto.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResponseMessage<T> {
+  
+  public String message;
+  public T item;
+
+}

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
@@ -1,0 +1,2 @@
+package com.nuguna.freview.servlet.member.api.cust.mybrand;public class NicknameUpdateServlet {
+}

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
@@ -79,11 +79,11 @@ public class NicknameUpdateServlet extends HttpServlet {
         JsonResponseUtil.sendBackJson(new ResponseMessage<>("성공적으로 수정했습니다.", toNickname), gson,
             out);
       }
-    } catch (NumberFormatException e) {
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "memberSeq는 null일 수 없습니다.");
     } catch (Exception e) {
       log.error("닉네임 변경 도중 에러가 발생했습니다.", e);
-      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      JsonResponseUtil.sendBackJson(new ResponseMessage<>("닉네임 변경 도중 서버 에러가 발생했습니다.", null), gson,
+          out);
     }
   }
 }

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
@@ -6,6 +6,7 @@ import com.nuguna.freview.dao.member.CustBrandDAO;
 import com.nuguna.freview.dto.common.ResponseMessage;
 import com.nuguna.freview.util.JsonRequestUtil;
 import com.nuguna.freview.util.JsonResponseUtil;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import javax.servlet.ServletException;
@@ -35,12 +36,13 @@ public class NicknameUpdateServlet extends HttpServlet {
 
     log.info("NicknameUpdateServlet.doPost");
 
+    BufferedReader in = request.getReader();
     PrintWriter out = response.getWriter();
     Gson gson = new Gson();
     String message = null;
 
     try {
-      JsonObject jsonObject = JsonRequestUtil.parseJson(request, response, gson);
+      JsonObject jsonObject = JsonRequestUtil.parseJson(in, gson);
       // 입력값 가져오기 ( 클라이언트에서 데이터를 올바르게 주는 경우만 가정 )
       // TODO : 추후 Input Data가 NULL 인 경우 또한 처리해주어야 함.
       int memberSeq = jsonObject.get("member_seq").getAsInt();
@@ -70,20 +72,20 @@ public class NicknameUpdateServlet extends HttpServlet {
 
       if (hasError) {
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-        JsonResponseUtil.sendBackJson(new ResponseMessage<>(message, null), gson, out);
+        JsonResponseUtil.sendBackJson(new ResponseMessage<>(message, null), out, gson);
       } else {
         // 닉네임 업데이트
         custBrandDAO.updateNickname(memberSeq, toNickname);
         // 성공 응답
         response.setStatus(HttpServletResponse.SC_OK);
-        JsonResponseUtil.sendBackJson(new ResponseMessage<>("성공적으로 수정했습니다.", toNickname), gson,
-            out);
+        JsonResponseUtil.sendBackJson(new ResponseMessage<>("성공적으로 수정했습니다.", toNickname), out,
+            gson);
       }
     } catch (Exception e) {
       log.error("닉네임 변경 도중 에러가 발생했습니다.", e);
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-      JsonResponseUtil.sendBackJson(new ResponseMessage<>("닉네임 변경 도중 서버 에러가 발생했습니다.", null), gson,
-          out);
+      JsonResponseUtil.sendBackJson(new ResponseMessage<>("닉네임 변경 도중 서버 에러가 발생했습니다.", null), out,
+          gson);
     }
   }
 }

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
@@ -1,2 +1,103 @@
-package com.nuguna.freview.servlet.member.api.cust.mybrand;public class NicknameUpdateServlet {
+package com.nuguna.freview.servlet.member.api.cust.mybrand;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.nuguna.freview.dao.member.CustBrandDAO;
+import com.nuguna.freview.dto.common.ResponseMessage;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@WebServlet("/api/cust/my-brand/nickname")
+public class NicknameUpdateServlet extends HttpServlet {
+
+  private CustBrandDAO custBrandDAO;
+
+  @Override
+  public void init() throws ServletException {
+    log.info("NicknameUpdateServlet 초기화");
+    custBrandDAO = new CustBrandDAO();
+  }
+
+  @Override
+  protected void doPost(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+
+    request.setCharacterEncoding("UTF-8");
+    response.setContentType("application/json;charset=UTF-8");
+
+    log.info("NicknameUpdateServlet.doPost");
+
+    Gson gson = new Gson();
+    PrintWriter out = response.getWriter();
+    ResponseMessage<String> responseJsonSource;
+    String message = null;
+
+    try {
+      // JSON Parsing
+      BufferedReader reader = request.getReader();
+      StringBuilder jsonBuilder = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        jsonBuilder.append(line);
+      }
+      String jsonString = jsonBuilder.toString();
+      JsonObject jsonObject = gson.fromJson(jsonString, JsonObject.class);
+
+      // 입력값 가져오기 ( 클라이언트에서 데이터를 올바르게 주는 경우만 가정 )
+      // TODO : 추후 Input Data가 NULL 인 경우 또한 처리해주어야 함.
+      Integer memberSeq = jsonObject.get("member_seq").getAsInt();
+      String fromNickname = jsonObject.get("from_nickname").getAsString();
+      String toNickname = jsonObject.get("to_nickname").getAsString();
+
+      // 입력값 검증
+      boolean hasError = false;
+
+      if (toNickname == null || toNickname.isEmpty()) {
+        message = "비어있는 닉네임 값입니다.";
+        hasError = true;
+      }
+
+      // 중복된 닉네임인지 확인
+      boolean isExistNickname = custBrandDAO.checkNicknameIsExist(toNickname);
+      if (isExistNickname) {
+        message = "중복된 닉네임입니다. 다시 입력해주세요.";
+        hasError = true;
+      }
+
+      // 기존과 동일한 닉네임
+      if (fromNickname.equals(toNickname)) {
+        message = "기존과 동일한 닉네임입니다.";
+        hasError = true;
+      }
+
+      if (hasError) {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        responseJsonSource = new ResponseMessage<>(message, null);
+        String jsonStr = gson.toJson(responseJsonSource);
+        out.print(jsonStr);
+        // JsonUtil.print(ResponseMessage<T> jsonSource)
+      } else {
+        // 닉네임 업데이트
+        custBrandDAO.updateNickname(memberSeq, toNickname);
+        // 성공 응답
+        response.setStatus(HttpServletResponse.SC_OK);
+        responseJsonSource = new ResponseMessage<>("성공적으로 수정했습니다.", toNickname); // 화면 업데이트
+        String jsonStr = gson.toJson(responseJsonSource);
+        out.print(jsonStr);
+      }
+    } catch (NumberFormatException e) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "memberSeq는 null일 수 없습니다.");
+    } catch (Exception e) {
+      log.error("닉네임 변경 도중 에러가 발생했습니다.", e);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+  }
 }

--- a/src/main/java/com/nuguna/freview/servlet/member/page/SampleServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/page/SampleServlet.java
@@ -1,0 +1,2 @@
+package com.nuguna.freview.servlet.member.page;public class SampleServlet {
+}

--- a/src/main/java/com/nuguna/freview/servlet/member/page/SampleServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/page/SampleServlet.java
@@ -1,2 +1,5 @@
-package com.nuguna.freview.servlet.member.page;public class SampleServlet {
+package com.nuguna.freview.servlet.member.page;
+
+public class SampleServlet {
+
 }

--- a/src/main/java/com/nuguna/freview/util/DbUtil.java
+++ b/src/main/java/com/nuguna/freview/util/DbUtil.java
@@ -1,0 +1,59 @@
+package com.nuguna.freview.util;
+
+import static com.nuguna.freview.config.DbConfig.DB_PW;
+import static com.nuguna.freview.config.DbConfig.DB_URL;
+import static com.nuguna.freview.config.DbConfig.DB_USER;
+import static com.nuguna.freview.config.DbConfig.DRIVER_NAME;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DbUtil {
+
+  public static Connection getConnection() {
+    Connection conn = null;
+    try {
+      Class.forName(DRIVER_NAME);
+      conn = DriverManager.getConnection(DB_URL, DB_USER, DB_PW);
+    } catch (ClassNotFoundException e) {
+      log.error("JDBC Driver not found");
+    } catch (SQLException e) {
+      log.error("connection failed");
+    }
+    return conn;
+  }
+
+  public static void closeResource(PreparedStatement pstmt, Connection conn, ResultSet rs) {
+    try {
+      if (rs != null) {
+        rs.close();
+      }
+      if (pstmt != null) {
+        pstmt.close();
+      }
+      if (conn != null) {
+        conn.close();
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static void closeResource(PreparedStatement pstmt, Connection conn) {
+    try {
+      if (pstmt != null) {
+        pstmt.close();
+      }
+      if (conn != null) {
+        conn.close();
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/com/nuguna/freview/util/JsonRequestUtil.java
+++ b/src/main/java/com/nuguna/freview/util/JsonRequestUtil.java
@@ -1,0 +1,28 @@
+package com.nuguna.freview.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class JsonRequestUtil {
+
+  public static JsonObject parseJson(HttpServletRequest request, HttpServletResponse response,
+      Gson gson)
+      throws IOException {
+    PrintWriter writer = response.getWriter();
+    // JSON Parsing
+    BufferedReader reader = request.getReader();
+    StringBuilder jsonBuilder = new StringBuilder();
+    String line;
+    while ((line = reader.readLine()) != null) {
+      jsonBuilder.append(line);
+    }
+    String jsonString = jsonBuilder.toString();
+    return gson.fromJson(jsonString, JsonObject.class);
+  }
+
+}

--- a/src/main/java/com/nuguna/freview/util/JsonRequestUtil.java
+++ b/src/main/java/com/nuguna/freview/util/JsonRequestUtil.java
@@ -4,21 +4,14 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.PrintWriter;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 public class JsonRequestUtil {
 
-  public static JsonObject parseJson(HttpServletRequest request, HttpServletResponse response,
-      Gson gson)
+  public static JsonObject parseJson(BufferedReader in, Gson gson)
       throws IOException {
-    PrintWriter writer = response.getWriter();
-    // JSON Parsing
-    BufferedReader reader = request.getReader();
     StringBuilder jsonBuilder = new StringBuilder();
     String line;
-    while ((line = reader.readLine()) != null) {
+    while ((line = in.readLine()) != null) {
       jsonBuilder.append(line);
     }
     String jsonString = jsonBuilder.toString();

--- a/src/main/java/com/nuguna/freview/util/JsonResponseUtil.java
+++ b/src/main/java/com/nuguna/freview/util/JsonResponseUtil.java
@@ -1,0 +1,15 @@
+package com.nuguna.freview.util;
+
+import com.google.gson.Gson;
+import com.nuguna.freview.dto.common.ResponseMessage;
+import java.io.PrintWriter;
+
+public class JsonResponseUtil {
+
+  public static <T> void sendBackJson(ResponseMessage<T> responseJsonSource, Gson gson,
+      PrintWriter out) {
+    String jsonStr = gson.toJson(responseJsonSource);
+    out.print(jsonStr);
+  }
+
+}

--- a/src/main/java/com/nuguna/freview/util/JsonResponseUtil.java
+++ b/src/main/java/com/nuguna/freview/util/JsonResponseUtil.java
@@ -6,8 +6,8 @@ import java.io.PrintWriter;
 
 public class JsonResponseUtil {
 
-  public static <T> void sendBackJson(ResponseMessage<T> responseJsonSource, Gson gson,
-      PrintWriter out) {
+  public static <T> void sendBackJson(ResponseMessage<T> responseJsonSource, PrintWriter out,
+      Gson gson) {
     String jsonStr = gson.toJson(responseJsonSource);
     out.print(jsonStr);
   }


### PR DESCRIPTION
1. 체험단 브랜드 페이지에서 닉네임 수정 ajax 요청을 위한 서버 측 API 개발 완료.

2. Http RequestBody와 ResponseBody를 JSON으로 파싱해주는 기능을 위한 util ( `JsonRequestUtil`, `JsonResponseUtil` ) 작성 완료.

3. DB 관련 공통 기능의 중복을 제거하기 위해 `DbConfig`와 `DbUtil`설정 클래스 작성 완료.

4. API 응답에 대해 예외 상황에서도 JSON으로 응답하도록 작성 완료