### PR TITLE
[feat-customer] 체험단 브랜드 페이지에서 유저 소개글 변경 API 구현 및 Gson 객체 리팩토링 & Json 파싱 에러에 대한 응답 코드 수정

### DIFF
--- a/src/main/java/com/nuguna/freview/dao/member/CustIntroduceDAO.java
+++ b/src/main/java/com/nuguna/freview/dao/member/CustIntroduceDAO.java
@@ -1,0 +1,32 @@
+package com.nuguna.freview.dao.member;
+
+import static com.nuguna.freview.util.DbUtil.closeResource;
+import static com.nuguna.freview.util.DbUtil.getConnection;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class CustIntroduceDAO {
+
+  public void updateIntroduce(int memberSeq, String toIntroduce) {
+    Connection conn = null;
+    PreparedStatement pstmt = null;
+
+    String sql = "UPDATE MEMBER "
+        + "SET introduce = ? "
+        + "WHERE member_seq = ?";
+
+    try {
+      conn = getConnection();
+      pstmt = conn.prepareStatement(sql);
+      pstmt.setString(1, toIntroduce);
+      pstmt.setInt(2, memberSeq);
+      pstmt.executeUpdate();
+    } catch (SQLException e) {
+      throw new RuntimeException("SQLException : 소개 변경 도중 예외 발생", e);
+    } finally {
+      closeResource(pstmt, conn);
+    }
+  }
+}

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/AgeGroupUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/AgeGroupUpdateServlet.java
@@ -20,11 +20,13 @@ import lombok.extern.slf4j.Slf4j;
 @WebServlet("/api/cust/my-brand/age-group")
 public class AgeGroupUpdateServlet extends HttpServlet {
 
+  private Gson gson;
   private CustAgeGroupDAO custAgeGroupDAO;
 
   @Override
   public void init() throws ServletException {
     log.info("AgeGroupUpdateServlet 초기화");
+    gson = new Gson();
     custAgeGroupDAO = new CustAgeGroupDAO();
   }
 
@@ -35,9 +37,7 @@ public class AgeGroupUpdateServlet extends HttpServlet {
     EncodingUtil.setEncodingToUTF8AndJson(request, response);
 
     log.info("AgeGroupUpdateServlet.doPost");
-
-    Gson gson = new Gson();
-
+    
     try {
       JsonObject jsonObject = JsonRequestUtil.parseJson(request.getReader(), gson);
       // 입력값 가져오기 ( 클라이언트에서 데이터를 올바르게 주는 경우만 가정 )

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/AgeGroupUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/AgeGroupUpdateServlet.java
@@ -2,6 +2,7 @@ package com.nuguna.freview.servlet.member.api.cust.mybrand;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.nuguna.freview.dao.member.CustAgeGroupDAO;
 import com.nuguna.freview.dto.common.ResponseMessage;
 import com.nuguna.freview.exception.UnsupportedAgeGroupException;
@@ -37,7 +38,7 @@ public class AgeGroupUpdateServlet extends HttpServlet {
     EncodingUtil.setEncodingToUTF8AndJson(request, response);
 
     log.info("AgeGroupUpdateServlet.doPost");
-    
+
     try {
       JsonObject jsonObject = JsonRequestUtil.parseJson(request.getReader(), gson);
       // 입력값 가져오기 ( 클라이언트에서 데이터를 올바르게 주는 경우만 가정 )
@@ -50,11 +51,16 @@ public class AgeGroupUpdateServlet extends HttpServlet {
 
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_OK,
           new ResponseMessage<>("성공적으로 수정되었습니다.", toAgeGroup), response, gson);
+    } catch (JsonParseException e) {
+      log.error("연령대 변경 요청에 대한 JSON 파싱 에러가 발생했습니다.", e);
+      JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
+          new ResponseMessage<>("요청 JSON의 형식에 문제가 있습니다.", null), response, gson);
     } catch (UnsupportedAgeGroupException e) {
+      log.error("유효하지 않은 연령대 요청입니다.");
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
           new ResponseMessage<>("유효하지 않은 연령대입니다.", null), response, gson);
     } catch (Exception e) {
-      log.error("연령대 변경 도중 에러가 발생했습니다.", e);
+      log.error("연령대 변경 도중 서버 에러가 발생했습니다.", e);
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
           new ResponseMessage<>("연령대 변경 도중 서버 에러가 발생했습니다.", null), response, gson);
     }

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/IntroduceUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/IntroduceUpdateServlet.java
@@ -2,6 +2,7 @@ package com.nuguna.freview.servlet.member.api.cust.mybrand;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.nuguna.freview.dao.member.CustIntroduceDAO;
 import com.nuguna.freview.dto.common.ResponseMessage;
 import com.nuguna.freview.util.EncodingUtil;
@@ -48,8 +49,12 @@ public class IntroduceUpdateServlet extends HttpServlet {
       custIntroduceDAO.updateIntroduce(memberSeq, toIntroduce);
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_OK,
           new ResponseMessage<>("성공적으로 수정했습니다.", toIntroduce), response, gson);
+    } catch (JsonParseException e) {
+      log.error("소개 변경 요청에 대한 JSON 파싱 에러가 발생했습니다.", e);
+      JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
+          new ResponseMessage<>("요청 JSON의 형식에 문제가 있습니다.", null), response, gson);
     } catch (Exception e) {
-      log.error("소개 변경 도중 에러가 발생했습니다.", e);
+      log.error("소개 변경 도중 서버 에러가 발생했습니다.", e);
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
           new ResponseMessage<>("소개 변경 도중 서버 에러가 발생했습니다.", null), response, gson);
     }

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/IntroduceUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/IntroduceUpdateServlet.java
@@ -2,9 +2,8 @@ package com.nuguna.freview.servlet.member.api.cust.mybrand;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.nuguna.freview.dao.member.CustAgeGroupDAO;
+import com.nuguna.freview.dao.member.CustIntroduceDAO;
 import com.nuguna.freview.dto.common.ResponseMessage;
-import com.nuguna.freview.exception.UnsupportedAgeGroupException;
 import com.nuguna.freview.util.EncodingUtil;
 import com.nuguna.freview.util.JsonRequestUtil;
 import com.nuguna.freview.util.JsonResponseUtil;
@@ -17,15 +16,15 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@WebServlet("/api/cust/my-brand/age-group")
-public class AgeGroupUpdateServlet extends HttpServlet {
+@WebServlet("/api/cust/my-brand/introduce")
+public class IntroduceUpdateServlet extends HttpServlet {
 
-  private CustAgeGroupDAO custAgeGroupDAO;
+  private CustIntroduceDAO custIntroduceDAO;
 
   @Override
   public void init() throws ServletException {
-    log.info("AgeGroupUpdateServlet 초기화");
-    custAgeGroupDAO = new CustAgeGroupDAO();
+    log.info("IntroduceUpdateServlet 초기화");
+    custIntroduceDAO = new CustIntroduceDAO();
   }
 
   @Override
@@ -34,7 +33,7 @@ public class AgeGroupUpdateServlet extends HttpServlet {
 
     EncodingUtil.setEncodingToUTF8AndJson(request, response);
 
-    log.info("AgeGroupUpdateServlet.doPost");
+    log.info("IntroduceUpdateServlet.doPost");
 
     Gson gson = new Gson();
 
@@ -44,19 +43,15 @@ public class AgeGroupUpdateServlet extends HttpServlet {
       // TODO : 추후 Input Data가 NULL 인 경우 또한 처리해주어야 함.
       // TODO : 서블릿 필터에서 memberSeq의 유효성을 체크해준다고 가정
       int memberSeq = jsonObject.get("member_seq").getAsInt();
-      String toAgeGroup = jsonObject.get("to_age_group").getAsString();
+      String toIntroduce = jsonObject.get("to_introduce").getAsString();
 
-      custAgeGroupDAO.updateAgeGroup(memberSeq, toAgeGroup);
-
+      custIntroduceDAO.updateIntroduce(memberSeq, toIntroduce);
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_OK,
-          new ResponseMessage<>("성공적으로 수정되었습니다.", toAgeGroup), response, gson);
-    } catch (UnsupportedAgeGroupException e) {
-      JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
-          new ResponseMessage<>("유효하지 않은 연령대입니다.", null), response, gson);
+          new ResponseMessage<>("성공적으로 수정했습니다.", toIntroduce), response, gson);
     } catch (Exception e) {
-      log.error("연령대 변경 도중 에러가 발생했습니다.", e);
+      log.error("소개 변경 도중 에러가 발생했습니다.", e);
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-          new ResponseMessage<>("연령대 변경 도중 서버 에러가 발생했습니다.", null), response, gson);
+          new ResponseMessage<>("소개 변경 도중 서버 에러가 발생했습니다.", null), response, gson);
     }
   }
 }

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/IntroduceUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/IntroduceUpdateServlet.java
@@ -19,11 +19,13 @@ import lombok.extern.slf4j.Slf4j;
 @WebServlet("/api/cust/my-brand/introduce")
 public class IntroduceUpdateServlet extends HttpServlet {
 
+  private Gson gson;
   private CustIntroduceDAO custIntroduceDAO;
 
   @Override
   public void init() throws ServletException {
     log.info("IntroduceUpdateServlet 초기화");
+    gson = new Gson();
     custIntroduceDAO = new CustIntroduceDAO();
   }
 
@@ -34,8 +36,6 @@ public class IntroduceUpdateServlet extends HttpServlet {
     EncodingUtil.setEncodingToUTF8AndJson(request, response);
 
     log.info("IntroduceUpdateServlet.doPost");
-
-    Gson gson = new Gson();
 
     try {
       JsonObject jsonObject = JsonRequestUtil.parseJson(request.getReader(), gson);

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
@@ -19,11 +19,13 @@ import lombok.extern.slf4j.Slf4j;
 @WebServlet("/api/cust/my-brand/nickname")
 public class NicknameUpdateServlet extends HttpServlet {
 
+  private Gson gson;
   private CustNicknameDAO custNicknameDAO;
 
   @Override
   public void init() throws ServletException {
     log.info("NicknameUpdateServlet 초기화");
+    gson = new Gson();
     custNicknameDAO = new CustNicknameDAO();
   }
 
@@ -35,7 +37,6 @@ public class NicknameUpdateServlet extends HttpServlet {
 
     log.info("NicknameUpdateServlet.doPost");
 
-    Gson gson = new Gson();
     String errorMessage = null;
 
     try {

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/NicknameUpdateServlet.java
@@ -2,6 +2,7 @@ package com.nuguna.freview.servlet.member.api.cust.mybrand;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.nuguna.freview.dao.member.CustNicknameDAO;
 import com.nuguna.freview.dto.common.ResponseMessage;
 import com.nuguna.freview.util.EncodingUtil;
@@ -77,6 +78,10 @@ public class NicknameUpdateServlet extends HttpServlet {
         JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_OK,
             new ResponseMessage<>("성공적으로 수정했습니다.", toNickname), response, gson);
       }
+    } catch (JsonParseException e) {
+      log.error("닉네임 변경 요청에 대한 JSON 파싱 에러가 발생했습니다.", e);
+      JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
+          new ResponseMessage<>("요청 JSON의 형식에 문제가 있습니다.", null), response, gson);
     } catch (Exception e) {
       log.error("닉네임 변경 도중 에러가 발생했습니다.", e);
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,

--- a/src/main/java/com/nuguna/freview/util/JsonRequestUtil.java
+++ b/src/main/java/com/nuguna/freview/util/JsonRequestUtil.java
@@ -2,13 +2,14 @@ package com.nuguna.freview.util;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import java.io.BufferedReader;
 import java.io.IOException;
 
 public class JsonRequestUtil {
 
   public static JsonObject parseJson(BufferedReader in, Gson gson)
-      throws IOException {
+      throws IOException, JsonParseException {
     StringBuilder jsonBuilder = new StringBuilder();
     String line;
     while ((line = in.readLine()) != null) {


### PR DESCRIPTION
1. 체험단 소개글 변경 API 구현 완료

2. `JsonRequesstUtil`의 `parseJson`에서 명시적으로 `JsonParsingException` 을 던지도록 명시화 & 서블릿에서 이를 처리하도록 변경 ( 기존 Json 파싱 실패 시 500 error - > 400 Bad Reqeust 로 나가도록 변경 )

3. Gson 객체의 내부 구현을 본 결과 모든 멤버 변수가 final, 그리고 Util 기능만 제공하기에 동시성 문제가 없음. 그렇기에 Gson 객체가 서블릿의 `doPost`가 호출될 때마다 생성되는 것은 메모리 낭비 및 성능을 잡아먹는다 판단함. 
4. -> Servlet의 `init()` 메서드가 호출될 때 초기화되도록 변경