### PR TITLE
[feat-customer] 체험단 브랜드 페이지에서 유저 활동 분야(FoodType) 변경 API 구현

### DIFF
--- a/src/main/java/com/nuguna/freview/dao/member/CustAgeGroupDAO.java
+++ b/src/main/java/com/nuguna/freview/dao/member/CustAgeGroupDAO.java
@@ -4,20 +4,20 @@ import static com.nuguna.freview.util.DbUtil.closeResource;
 import static com.nuguna.freview.util.DbUtil.getConnection;
 
 import com.nuguna.freview.entity.member.AgeGroup;
-import com.nuguna.freview.exception.UnsupportedAgeGroupException;
+import com.nuguna.freview.exception.IllegalAgeGroupException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 public class CustAgeGroupDAO {
 
-  public void updateAgeGroup(int memberSeq, String toAgeGroup) throws UnsupportedAgeGroupException {
+  public void updateAgeGroup(int memberSeq, String toAgeGroup) throws IllegalAgeGroupException {
     Connection conn = null;
     PreparedStatement pstmt = null;
 
     try {
       AgeGroup.from(toAgeGroup);
-    } catch (UnsupportedAgeGroupException e) {
+    } catch (IllegalAgeGroupException e) {
       throw e;
     }
 

--- a/src/main/java/com/nuguna/freview/dao/member/CustFoodTypeDAO.java
+++ b/src/main/java/com/nuguna/freview/dao/member/CustFoodTypeDAO.java
@@ -4,7 +4,7 @@ import static com.nuguna.freview.util.DbUtil.closeResource;
 import static com.nuguna.freview.util.DbUtil.getConnection;
 
 import com.nuguna.freview.entity.member.foodtype.FoodTypeGubun;
-import com.nuguna.freview.exception.UnsupportedFoodTypeException;
+import com.nuguna.freview.exception.IllegalFoodTypeException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -24,7 +24,7 @@ public class CustFoodTypeDAO {
       foodTypeGubuns = foodTypeNames.stream()
           .map(FoodTypeGubun::from)
           .collect(Collectors.toList());
-    } catch (UnsupportedFoodTypeException e) {
+    } catch (IllegalFoodTypeException e) {
       throw e;
     }
 

--- a/src/main/java/com/nuguna/freview/dao/member/CustFoodTypeDAO.java
+++ b/src/main/java/com/nuguna/freview/dao/member/CustFoodTypeDAO.java
@@ -1,0 +1,105 @@
+package com.nuguna.freview.dao.member;
+
+import static com.nuguna.freview.util.DbUtil.closeResource;
+import static com.nuguna.freview.util.DbUtil.getConnection;
+
+import com.nuguna.freview.entity.member.foodtype.FoodTypeGubun;
+import com.nuguna.freview.exception.UnsupportedFoodTypeException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CustFoodTypeDAO {
+
+  public void updateFoodType(int memberSeq, List<String> foodTypeNames) {
+
+    List<FoodTypeGubun> foodTypeGubuns;
+    try {
+      foodTypeGubuns = foodTypeNames.stream()
+          .map(FoodTypeGubun::from)
+          .collect(Collectors.toList());
+    } catch (UnsupportedFoodTypeException e) {
+      throw e;
+    }
+
+    Connection conn = null;
+    PreparedStatement deletePstmt = null;
+    PreparedStatement selectPstmt = null;
+    PreparedStatement insertPstmt = null;
+    ResultSet rs = null;
+
+    String deleteSql = "DELETE FROM MEMBER_FOOD_TYPE "
+        + "WHERE member_seq = ?";
+
+    // foodTypeGubuns 리스트의 크기만큼 물음표를 생성
+    String placeholders = foodTypeGubuns.stream()
+        .map(g -> "?")
+        .collect(Collectors.joining(", "));
+
+    String selectSql = "SELECT food_type_seq FROM FOOD_TYPE "
+        + "WHERE name IN (" + placeholders + ")";
+
+    String insertSql = "INSERT INTO MEMBER_FOOD_TYPE (member_seq, food_type_seq) "
+        + "VALUES (?,?)";
+
+    try {
+      conn = getConnection();
+
+      // 트랜잭션을 시작
+      conn.setAutoCommit(false);
+
+      // 1. 기존 Member - FoodType 매핑 삭제
+      deletePstmt = conn.prepareStatement(deleteSql);
+      deletePstmt.setInt(1, memberSeq);
+      deletePstmt.executeUpdate();
+
+      // 2. foodTypeGubun들에 해당하는 food_type_seq 조회
+      selectPstmt = conn.prepareStatement(selectSql);
+
+      int index = 1;
+      for (FoodTypeGubun foodTypeGubun : foodTypeGubuns) {
+        selectPstmt.setString(index++, foodTypeGubun.getCodeName());
+      }
+      rs = selectPstmt.executeQuery();
+
+      List<Integer> foodTypeSeqs = new ArrayList<>();
+      log.info("RS : " + rs.toString());
+      while (rs.next()) {
+        foodTypeSeqs.add(rs.getInt("food_type_seq"));
+      }
+
+      log.info(foodTypeSeqs.toString());
+      // 3. 선택된 FoodTypeSeq들을 Member와 매핑해준다.
+      insertPstmt = conn.prepareStatement(insertSql);
+      for (Integer foodTypeSeq : foodTypeSeqs) {
+        insertPstmt.setInt(1, memberSeq);
+        insertPstmt.setInt(2, foodTypeSeq);
+        insertPstmt.addBatch();
+      }
+      insertPstmt.executeBatch();
+
+      // 트랜잭션 커밋
+      conn.commit();
+    } catch (SQLException e) {
+      if (conn != null) {
+        try {
+          conn.rollback();
+        } catch (SQLException rollbackEx) {
+          throw new RuntimeException("예외가 발생했으나 롤백에 실패함");
+        }
+      }
+      throw new RuntimeException("SQLException : 활동 분야 변경 도중 예외 발생", e);
+    } finally {
+      closeResource(rs);
+      closeResource(deletePstmt);
+      closeResource(selectPstmt);
+      closeResource(insertPstmt, conn);
+    }
+  }
+}

--- a/src/main/java/com/nuguna/freview/entity/member/AgeGroup.java
+++ b/src/main/java/com/nuguna/freview/entity/member/AgeGroup.java
@@ -1,6 +1,6 @@
 package com.nuguna.freview.entity.member;
 
-import com.nuguna.freview.exception.UnsupportedAgeGroupException;
+import com.nuguna.freview.exception.IllegalAgeGroupException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -27,7 +27,7 @@ public enum AgeGroup {
         return a;
       }
     }
-    throw new UnsupportedAgeGroupException("유효하지 않은 AgeGroup 입력 : " + ageGroup);
+    throw new IllegalAgeGroupException("유효하지 않은 AgeGroup 입력 : " + ageGroup);
   }
 
 }

--- a/src/main/java/com/nuguna/freview/entity/member/foodtype/FoodType.java
+++ b/src/main/java/com/nuguna/freview/entity/member/foodtype/FoodType.java
@@ -14,13 +14,13 @@ import lombok.ToString;
 public class FoodType {
 
   private Integer foodTypeSeq;
-  private FoodTypeGubun name;
+  private FoodTypeGubun codeName;
 
-  public String getName() {
-    return name != null ? name.getCode() : null;
+  public String getCodeName() {
+    return codeName != null ? codeName.getCodeName() : null;
   }
 
   public void setName(String name) {
-    this.name = FoodTypeGubun.from(name);
+    this.codeName = FoodTypeGubun.from(name);
   }
 }

--- a/src/main/java/com/nuguna/freview/entity/member/foodtype/FoodTypeGubun.java
+++ b/src/main/java/com/nuguna/freview/entity/member/foodtype/FoodTypeGubun.java
@@ -1,6 +1,6 @@
 package com.nuguna.freview.entity.member.foodtype;
 
-import com.nuguna.freview.exception.UnsupportedFoodTypeException;
+import com.nuguna.freview.exception.IllegalFoodTypeException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -24,6 +24,6 @@ public enum FoodTypeGubun {
         return g;
       }
     }
-    throw new UnsupportedFoodTypeException("유효하지 않은 FoodTypeGubun 입력 : " + foodTypeName);
+    throw new IllegalFoodTypeException("유효하지 않은 FoodTypeGubun 입력 : " + foodTypeName);
   }
 }

--- a/src/main/java/com/nuguna/freview/entity/member/foodtype/FoodTypeGubun.java
+++ b/src/main/java/com/nuguna/freview/entity/member/foodtype/FoodTypeGubun.java
@@ -1,5 +1,6 @@
 package com.nuguna.freview.entity.member.foodtype;
 
+import com.nuguna.freview.exception.UnsupportedFoodTypeException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -15,14 +16,14 @@ public enum FoodTypeGubun {
   BC("BC"),
   ETC("ETC");
 
-  private final String code;
+  private final String codeName;
 
-  public static FoodTypeGubun from(String code) {
+  public static FoodTypeGubun from(String foodTypeName) {
     for (FoodTypeGubun g : FoodTypeGubun.values()) {
-      if (g.getCode().equalsIgnoreCase(code)) {
+      if (g.getCodeName().equalsIgnoreCase(foodTypeName)) {
         return g;
       }
     }
-    throw new IllegalArgumentException("유효하지 않은 FoodTypeGubun 입력 : " + code);
+    throw new UnsupportedFoodTypeException("유효하지 않은 FoodTypeGubun 입력 : " + foodTypeName);
   }
 }

--- a/src/main/java/com/nuguna/freview/exception/IllegalAgeGroupException.java
+++ b/src/main/java/com/nuguna/freview/exception/IllegalAgeGroupException.java
@@ -1,0 +1,8 @@
+package com.nuguna.freview.exception;
+
+public class IllegalAgeGroupException extends RuntimeException {
+
+  public IllegalAgeGroupException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/nuguna/freview/exception/IllegalFoodTypeException.java
+++ b/src/main/java/com/nuguna/freview/exception/IllegalFoodTypeException.java
@@ -1,0 +1,8 @@
+package com.nuguna.freview.exception;
+
+public class IllegalFoodTypeException extends RuntimeException {
+
+  public IllegalFoodTypeException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/nuguna/freview/exception/UnsupportedAgeGroupException.java
+++ b/src/main/java/com/nuguna/freview/exception/UnsupportedAgeGroupException.java
@@ -1,8 +1,0 @@
-package com.nuguna.freview.exception;
-
-public class UnsupportedAgeGroupException extends RuntimeException {
-
-  public UnsupportedAgeGroupException(String message) {
-    super(message);
-  }
-}

--- a/src/main/java/com/nuguna/freview/exception/UnsupportedFoodTypeException.java
+++ b/src/main/java/com/nuguna/freview/exception/UnsupportedFoodTypeException.java
@@ -1,8 +1,0 @@
-package com.nuguna.freview.exception;
-
-public class UnsupportedFoodTypeException extends RuntimeException {
-
-  public UnsupportedFoodTypeException(String message) {
-    super(message);
-  }
-}

--- a/src/main/java/com/nuguna/freview/exception/UnsupportedFoodTypeException.java
+++ b/src/main/java/com/nuguna/freview/exception/UnsupportedFoodTypeException.java
@@ -1,0 +1,8 @@
+package com.nuguna.freview.exception;
+
+public class UnsupportedFoodTypeException extends RuntimeException {
+
+  public UnsupportedFoodTypeException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/AgeGroupUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/AgeGroupUpdateServlet.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.nuguna.freview.dao.member.CustAgeGroupDAO;
 import com.nuguna.freview.dto.common.ResponseMessage;
-import com.nuguna.freview.exception.UnsupportedAgeGroupException;
+import com.nuguna.freview.exception.IllegalAgeGroupException;
 import com.nuguna.freview.util.EncodingUtil;
 import com.nuguna.freview.util.JsonRequestUtil;
 import com.nuguna.freview.util.JsonResponseUtil;
@@ -55,7 +55,7 @@ public class AgeGroupUpdateServlet extends HttpServlet {
       log.error("연령대 변경 요청에 대한 JSON 파싱 에러가 발생했습니다.", e);
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
           new ResponseMessage<>("요청 JSON의 형식에 문제가 있습니다.", null), response, gson);
-    } catch (UnsupportedAgeGroupException e) {
+    } catch (IllegalAgeGroupException e) {
       log.error("유효하지 않은 연령대 요청입니다.");
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
           new ResponseMessage<>("유효하지 않은 연령대입니다.", null), response, gson);

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/FoodTypeUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/FoodTypeUpdateServlet.java
@@ -7,7 +7,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.nuguna.freview.dao.member.CustFoodTypeDAO;
 import com.nuguna.freview.dto.common.ResponseMessage;
-import com.nuguna.freview.exception.UnsupportedFoodTypeException;
+import com.nuguna.freview.exception.IllegalFoodTypeException;
 import com.nuguna.freview.util.EncodingUtil;
 import com.nuguna.freview.util.JsonRequestUtil;
 import com.nuguna.freview.util.JsonResponseUtil;
@@ -63,7 +63,7 @@ public class FoodTypeUpdateServlet extends HttpServlet {
       log.error("활동 분야 변경 요청에 대한 JSON 파싱 에러가 발생했습니다.", e);
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
           new ResponseMessage<>("요청 JSON의 형식에 문제가 있습니다.", null), response, gson);
-    } catch (UnsupportedFoodTypeException e) {
+    } catch (IllegalFoodTypeException e) {
       log.error("유효하지 않은 활동 분야 요청입니다.");
       JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
           new ResponseMessage<>("유효하지 않은 활동 분야입니다.", null), response, gson);

--- a/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/FoodTypeUpdateServlet.java
+++ b/src/main/java/com/nuguna/freview/servlet/member/api/cust/mybrand/FoodTypeUpdateServlet.java
@@ -1,0 +1,77 @@
+package com.nuguna.freview.servlet.member.api.cust.mybrand;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.nuguna.freview.dao.member.CustFoodTypeDAO;
+import com.nuguna.freview.dto.common.ResponseMessage;
+import com.nuguna.freview.exception.UnsupportedFoodTypeException;
+import com.nuguna.freview.util.EncodingUtil;
+import com.nuguna.freview.util.JsonRequestUtil;
+import com.nuguna.freview.util.JsonResponseUtil;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@WebServlet("/api/cust/my-brand/food-type")
+public class FoodTypeUpdateServlet extends HttpServlet {
+
+  private Gson gson;
+  private CustFoodTypeDAO custFoodTypeDAO;
+
+  @Override
+  public void init() throws ServletException {
+    log.info("FoodTypeUpdateServlet 초기화");
+    gson = new Gson();
+    custFoodTypeDAO = new CustFoodTypeDAO();
+  }
+
+  @Override
+  protected void doPost(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+
+    EncodingUtil.setEncodingToUTF8AndJson(request, response);
+
+    log.info("FoodTypeUpdateServlet.doPost");
+
+    try {
+      JsonObject jsonObject = JsonRequestUtil.parseJson(request.getReader(), gson);
+      // 입력값 가져오기 ( 클라이언트에서 데이터를 올바르게 주는 경우만 가정 )
+      // TODO : 추후 Input Data가 NULL 인 경우 또한 처리해주어야 함.
+      // TODO : 서블릿 필터에서 memberSeq의 유효성을 체크해준다고 가정
+      int memberSeq = jsonObject.get("member_seq").getAsInt();
+      JsonArray foodTypes = jsonObject.get("to_food_types").getAsJsonArray();
+
+      List<String> foodTypeNames = foodTypes.asList().stream()
+          .map(JsonElement::getAsString)
+          .collect(Collectors.toList());
+
+      custFoodTypeDAO.updateFoodType(memberSeq, foodTypeNames);
+
+      JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_OK,
+          new ResponseMessage<>("성공적으로 수정되었습니다.", foodTypeNames), response, gson);
+    } catch (JsonParseException e) {
+      log.error("활동 분야 변경 요청에 대한 JSON 파싱 에러가 발생했습니다.", e);
+      JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
+          new ResponseMessage<>("요청 JSON의 형식에 문제가 있습니다.", null), response, gson);
+    } catch (UnsupportedFoodTypeException e) {
+      log.error("유효하지 않은 활동 분야 요청입니다.");
+      JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_BAD_REQUEST,
+          new ResponseMessage<>("유효하지 않은 활동 분야입니다.", null), response, gson);
+    } catch (Exception e) {
+      log.error("활동 분야 변경 도중 서버 에러가 발생했습니다.", e);
+      JsonResponseUtil.sendBackJsonWithStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          new ResponseMessage<>("활동 분야 변경 도중 서버 에러가 발생했습니다.", null), response, gson);
+    }
+  }
+
+}

--- a/src/main/java/com/nuguna/freview/util/DbUtil.java
+++ b/src/main/java/com/nuguna/freview/util/DbUtil.java
@@ -56,4 +56,24 @@ public class DbUtil {
       throw new RuntimeException(e);
     }
   }
+
+  public static void closeResource(ResultSet rs) {
+    try {
+      if (rs != null) {
+        rs.close();
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static void closeResource(PreparedStatement pstmt) {
+    try {
+      if (pstmt != null) {
+        pstmt.close();
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
 }


### PR DESCRIPTION
1. 유저 활동 분야(FoodType) 변경 API 구현 완료

2. `AgeGroup`, `FoodType` 관련 예외 네이밍 변경 ( `Unsupported~`-> `Illegal~` )

3. `util` 패키지의 `DbUtil` 에 자원 반납을 위한 편의 메서드들 오버로딩 ( `PreparedStatment` 만 반납, `ResultSet` 만 반납 )